### PR TITLE
Add a variable for ALB security polices

### DIFF
--- a/alb_template/aws_lb_listener.tf
+++ b/alb_template/aws_lb_listener.tf
@@ -3,6 +3,7 @@ resource "aws_lb_listener" "https" {
 
   protocol        = "HTTPS"
   port            = 443
+  ssl_policy      = var.ssl_policy
   certificate_arn = aws_acm_certificate.https-certificate.arn
 
   default_action {
@@ -22,4 +23,3 @@ resource "aws_lb_listener" "http" {
     type             = "forward"
   }
 }
-

--- a/alb_template/variables.tf
+++ b/alb_template/variables.tf
@@ -37,7 +37,7 @@ variable "acm_certificate_alternative_names" {
 
 variable "ssl_policy" {
   type        = string
-  default     = "ELBSecurityPolicy-2016-08"
+  default     = ""
   description = "The name of the SSL Policy for the listener."
 }
 

--- a/alb_template/variables.tf
+++ b/alb_template/variables.tf
@@ -35,6 +35,12 @@ variable "acm_certificate_alternative_names" {
   description = "Alternative names of the SSL certificate. If you use CNAME for the domain_name, you should set FQDN of CNAMEs to allow access from the CNAMEs."
 }
 
+variable "ssl_policy" {
+  type        = string
+  default     = "ELBSecurityPolicy-2016-08"
+  description = "The name of the SSL Policy for the listener."
+}
+
 variable "ingress_cidr_blocks" {
   type        = list(string)
   default     = ["0.0.0.0/0"]


### PR DESCRIPTION
The following ELB security policies are available:  
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies

This pull request allows the user to select a policy.