### PR TITLE
Add deployment_maximum_percent to ecs_web_service_template

### DIFF
--- a/ecs_web_service_template/aws_ecs_service.tf
+++ b/ecs_web_service_template/aws_ecs_service.tf
@@ -4,6 +4,7 @@ resource "aws_ecs_service" "main-non-awsvpc" {
   cluster = var.ecs_cluster_id
   name    = "${var.envname}-${var.application_name}"
 
+  deployment_maximum_percent         = var.ecs_deployment_maximum_percent
   deployment_minimum_healthy_percent = var.ecs_deployment_minimum_healthy_percent
   desired_count                      = var.ecs_service_desired_count
   launch_type                        = var.launch_type
@@ -25,6 +26,7 @@ resource "aws_ecs_service" "main-awsvpc" {
   cluster = var.ecs_cluster_id
   name    = "${var.envname}-${var.application_name}"
 
+  deployment_maximum_percent         = var.ecs_deployment_maximum_percent
   deployment_minimum_healthy_percent = var.ecs_deployment_minimum_healthy_percent
   desired_count                      = var.ecs_service_desired_count
   launch_type                        = var.launch_type

--- a/ecs_web_service_template/variables.tf
+++ b/ecs_web_service_template/variables.tf
@@ -127,6 +127,10 @@ variable "container_definitions" {
   description = "aws_ecs_task_definition.container_definitions, 'containerDefinitions' of the ECS task JSON"
 }
 
+variable "ecs_deployment_maximum_percent" {
+  description = "aws_ecs_service.ecs_deployment_maximum_percent (0 to 200)"
+}
+
 variable "ecs_deployment_minimum_healthy_percent" {
   description = "aws_ecs_service.deployment_minimum_healthy_percent (0 to 100)"
 }

--- a/ecs_web_service_template/variables.tf
+++ b/ecs_web_service_template/variables.tf
@@ -128,10 +128,14 @@ variable "container_definitions" {
 }
 
 variable "ecs_deployment_maximum_percent" {
+  type = number
+  default = null
   description = "aws_ecs_service.ecs_deployment_maximum_percent (0 to 200)"
 }
 
 variable "ecs_deployment_minimum_healthy_percent" {
+  type = number
+  default = null
   description = "aws_ecs_service.deployment_minimum_healthy_percent (0 to 100)"
 }
 


### PR DESCRIPTION
There is no `deployment_maximum_percent` parameter in the `aws_ecs_service` module.

https://www.terraform.io/docs/providers/aws/r/ecs_service.html#deployment_maximum_percent