### PR TITLE
Output the arn_suffix parameter of ALB for CloudWatch Metrics

### DIFF
--- a/alb_template/outputs.tf
+++ b/alb_template/outputs.tf
@@ -1,3 +1,7 @@
+output "lb_arn_suffix" {
+  value = aws_lb.main.arn_suffix
+}
+
 output "lb_zone_id" {
   value = aws_lb.main.zone_id
 }


### PR DESCRIPTION
I added outputs in order to send ALB alarms from CloudWatch Metrics.  

https://www.terraform.io/docs/providers/aws/r/lb.html#arn_suffix