### PR TITLE
Fix guardduty lambda path in Terraform 0.12

### DIFF
--- a/guardduty_slack/lambda_sns_to_slack/aws_lambda_function.tf
+++ b/guardduty_slack/lambda_sns_to_slack/aws_lambda_function.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "lambda" {
   publish       = true
   function_name = "${var.basename}"
 
-  filename         = "${substr(data.archive_file.lambda.output_path, length(path.cwd) + 1, -1)}"
+  filename         = "${substr(data.archive_file.lambda.output_path, length(abspath(path.cwd)) + 1, -1)}"
   handler          = "index.lambda_hander"
   source_code_hash = "${data.archive_file.lambda.output_base64sha256}"
 
@@ -29,6 +29,6 @@ resource "aws_lambda_function" "lambda" {
 
 data "archive_file" "lambda" {
   type        = "zip"
-  source_dir  = "${path.module}/src"
-  output_path = "${path.module}/temp/${var.basename}-dist.zip"
+  source_dir  = "${abspath(path.module)}/src"
+  output_path = "${abspath(path.module)}/temp/${var.basename}-dist.zip"
 }


### PR DESCRIPTION
In Terraform0.12, I occured the following error.

```
Error: Unable to load "ack/temp/guardduty-sns-to-slack-dev-dist.zip": open ack/temp/guardduty-sns-to-slack-dev-dist.zip: no such file or directory

  on .terraform/modules/guardduty/guardduty_slack/lambda_sns_to_slack/aws_lambda_function.tf line 5, in resource "aws_lambda_function" "lambda":
   5: resource "aws_lambda_function" "lambda" {
```

We will fix it with this PR.