### PR TITLE
Add aws_alb_target_group.arn_suffix to outputs for CloudWatch Metrics

### DIFF
--- a/alb_template/outputs.tf
+++ b/alb_template/outputs.tf
@@ -17,6 +17,10 @@ output "default_target_group_arn" {
   value = aws_lb_target_group.default-target-group.arn
 }
 
+output "default_target_group_arn_suffix" {
+  value = aws_lb_target_group.default-target-group.arn_suffix
+}
+
 output "security_group_id" {
   value = aws_security_group.loadbalancer.id
 }

--- a/ecs_web_service_template/outputs.tf
+++ b/ecs_web_service_template/outputs.tf
@@ -1,0 +1,3 @@
+output "target_group_arn_suffix" {
+  value = aws_alb_target_group.main.arn_suffix
+}


### PR DESCRIPTION
Add outputs to use in CloudWatch Metrics.

https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#arn_suffix