### PR TITLE
Lambda の実行回数 (Invocations) も監視対象として必須にする

### DIFF
--- a/lambda_monitoring/aws_cloudwatch_metric_alarm.tf
+++ b/lambda_monitoring/aws_cloudwatch_metric_alarm.tf
@@ -66,3 +66,25 @@ resource "aws_cloudwatch_metric_alarm" "lambda_duration" {
 
   alarm_actions = [ var.sns_arn ]
 }
+
+resource "aws_cloudwatch_metric_alarm" "lambda_invocations" {
+  alarm_name = "${var.function_name}-invocations"
+  alarm_description = "Lambda \"${var.function_name}\" too many invocations"
+
+  namespace = "AWS/Lambda"
+  metric_name = "Invocations"
+  statistic = "Sum"
+  period = var.max_invocations_window_seconds
+  evaluation_periods = "1"
+
+  treat_missing_data = "notBreaching"
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold = var.max_invocations
+
+  dimensions = {
+    FunctionName = var.function_name
+  }
+
+  alarm_actions = [ var.sns_arn ]
+}

--- a/lambda_monitoring/aws_cloudwatch_metric_alarm.tf
+++ b/lambda_monitoring/aws_cloudwatch_metric_alarm.tf
@@ -67,20 +67,42 @@ resource "aws_cloudwatch_metric_alarm" "lambda_duration" {
   alarm_actions = [ var.sns_arn ]
 }
 
-resource "aws_cloudwatch_metric_alarm" "lambda_invocations" {
-  alarm_name = "${var.function_name}-invocations"
+resource "aws_cloudwatch_metric_alarm" "lambda_invocations_max" {
+  alarm_name = "${var.function_name}-invocations-max"
   alarm_description = "Lambda \"${var.function_name}\" too many invocations"
 
   namespace = "AWS/Lambda"
   metric_name = "Invocations"
   statistic = "Sum"
-  period = var.max_invocations_window_seconds
+  period = var.invocations_window_seconds
   evaluation_periods = "1"
 
   treat_missing_data = "notBreaching"
 
   comparison_operator = "GreaterThanThreshold"
-  threshold = var.max_invocations
+  threshold = var.invocations_max
+
+  dimensions = {
+    FunctionName = var.function_name
+  }
+
+  alarm_actions = [ var.sns_arn ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_invocations_min" {
+  alarm_name = "${var.function_name}-invocations-min"
+  alarm_description = "Lambda \"${var.function_name}\" too few invocations"
+
+  namespace = "AWS/Lambda"
+  metric_name = "Invocations"
+  statistic = "Sum"
+  period = var.invocations_window_seconds
+  evaluation_periods = "1"
+
+  treat_missing_data = "notBreaching"
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold = var.invocations_min
 
   dimensions = {
     FunctionName = var.function_name

--- a/lambda_monitoring/variables.tf
+++ b/lambda_monitoring/variables.tf
@@ -9,3 +9,12 @@ variable "duration_alarm_ms" {
   default = 0
   description = "Milliseconds threshold to alarm too long lambda execution. 0 (default) to disable this alarm."
 }
+
+variable "max_invocations" {
+  description = "Threshold to alarm too many invocations."
+}
+
+variable "max_invocations_window_seconds" {
+  default = 5 * 60
+  description = "Window (duration) to check max_invocations. Unit is [sec]."
+}

--- a/lambda_monitoring/variables.tf
+++ b/lambda_monitoring/variables.tf
@@ -10,11 +10,15 @@ variable "duration_alarm_ms" {
   description = "Milliseconds threshold to alarm too long lambda execution. 0 (default) to disable this alarm."
 }
 
-variable "max_invocations" {
+variable "invocations_max" {
   description = "Threshold to alarm too many invocations."
 }
 
-variable "max_invocations_window_seconds" {
+variable "invocations_min" {
+  description = "Threshold to alarm too many invocations."
+}
+
+variable "invocations_window_seconds" {
   default = 5 * 60
-  description = "Window (duration) to check max_invocations. Unit is [sec]."
+  description = "Window (duration) to check max,min_invocations. Unit is [sec]."
 }


### PR DESCRIPTION
既存の `lambda_monitoring` module について、既存ではエラーおよび実行時間超過を監視する構成だったのですが、それに加えて実行回数 (Invocation) も監視対象にします。